### PR TITLE
Add super-linter to pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,25 +2,4 @@
     name: linting (via docker)
     entry: /linting.sh
     language: docker
--   id: super-linting
-    name: super-linter (via docker)
-    language: docker_image
-    entry: >
-        -e RUN_LOCAL=true
-        -e DEFAULT_BRANCH=main
-        -e DEFAULT_WORKSPACE=/src
-        -e BASH_SEVERITY=warning
-        -e VALIDATE_BASH=true
-        -e VALIDATE_BASH_EXEC=true
-        -e VALIDATE_CSS=true
-        -e VALIDATE_DOCKERFILE_HADOLINT=true
-        -e VALIDATE_GITHUB_ACTIONS=true
-        -e VALIDATE_HTML=true
-        -e VALIDATE_JAVASCRIPT_ES=true
-        -e VALIDATE_JAVASCRIPT_STANDARD=true
-        -e VALIDATE_JSON=true
-        -e VALIDATE_MARKDOWN=true
-        -e VALIDATE_POWERSHELL=true
-        -e VALIDATE_RENOVATE=true
-        -e VALIDATE_XML=true
-        mundialis/super-linter:latest
+    require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,3 +2,25 @@
     name: linting (via docker)
     entry: /linting.sh
     language: docker
+-   id: super-linting
+    name: super-linter (via docker)
+    language: docker_image
+    entry: >
+        -e RUN_LOCAL=true
+        -e DEFAULT_BRANCH=main
+        -e DEFAULT_WORKSPACE=/src
+        -e BASH_SEVERITY=warning
+        -e VALIDATE_BASH=true
+        -e VALIDATE_BASH_EXEC=true
+        -e VALIDATE_CSS=true
+        -e VALIDATE_DOCKERFILE_HADOLINT=true
+        -e VALIDATE_GITHUB_ACTIONS=true
+        -e VALIDATE_HTML=true
+        -e VALIDATE_JAVASCRIPT_ES=true
+        -e VALIDATE_JAVASCRIPT_STANDARD=true
+        -e VALIDATE_JSON=true
+        -e VALIDATE_MARKDOWN=true
+        -e VALIDATE_POWERSHELL=true
+        -e VALIDATE_RENOVATE=true
+        -e VALIDATE_XML=true
+        mundialis/super-linter:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY pre_commit_hooks/linting.sh /linting.sh
 
 CMD [ "bash /linting.sh" ]
 
+# Below for super-linter
 
 # pre-commit seems to set too strict permissions:
 # error: could not lock config file //.gitconfig: Permission denied
@@ -31,9 +32,9 @@ CMD [ "bash /linting.sh" ]
 RUN sed -i 's+git config --global --add safe.directory+git config --add safe.directory+g' /action/lib/linter.sh
 
 # save to be able to export later
-RUN echo "export RUN_LOCAL=TRUE" >> /super-linter.txt
-RUN echo "export DEFAULT_BRANCH=main" >> /super-linter.txt
-RUN echo "export DEFAULT_WORKSPACE=/src" >> /super-linter.txt
+RUN echo "RUN_LOCAL=TRUE" >> /super-linter.txt
+RUN echo "DEFAULT_BRANCH=main" >> /super-linter.txt
+RUN echo "DEFAULT_WORKSPACE=/src" >> /super-linter.txt
 RUN echo BASH_SEVERITY=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."BASH_SEVERITY"'.default) >> /super-linter.txt
 RUN echo VALIDATE_BASH=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH"'.default) >> /super-linter.txt
 RUN echo VALIDATE_BASH_EXEC=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH_EXEC"'.default) >> /super-linter.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM ghcr.io/super-linter/super-linter:latest
-# FROM python:3-slim
 
 # This Dockerfile is used by the linting pre-commit hook.
 # Unfortunately there is no config option yet to specify the name or path
@@ -25,21 +24,28 @@ COPY pre_commit_hooks/linting.sh /linting.sh
 CMD [ "bash /linting.sh" ]
 
 
+# pre-commit seems to set too strict permissions:
+# error: could not lock config file //.gitconfig: Permission denied
+# Therefore do not configure globally
+# https://github.com/super-linter/super-linter/blob/main/lib/linter.sh#L345
+RUN sed -i 's+git config --global --add safe.directory+git config --add safe.directory+g' /action/lib/linter.sh
 
-#######
 # save to be able to export later
-RUN echo BASH_SEVERITY=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."BASH_SEVERITY"'.default) >> /environment.txt
-RUN echo VALIDATE_BASH=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH"'.default) >> /environment.txt
-RUN echo VALIDATE_BASH_EXEC=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH_EXEC"'.default) >> /environment.txt
-RUN echo VALIDATE_CSS=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_CSS"'.default) >> /environment.txt
-RUN echo VALIDATE_DOCKERFILE_HADOLINT=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_DOCKERFILE_HADOLINT"'.default) >> /environment.txt
-RUN echo VALIDATE_GITHUB_ACTIONS=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_GITHUB_ACTIONS"'.default) >> /environment.txt
-RUN echo VALIDATE_HTML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_HTML"'.default) >> /environment.txt
-RUN echo VALIDATE_JAVASCRIPT_ES=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JAVASCRIPT_ES"'.default) >> /environment.txt
-RUN echo VALIDATE_JAVASCRIPT_STANDARD=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JAVASCRIPT_STANDARD"'.default) >> /environment.txt
-RUN echo VALIDATE_JSON=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JSON"'.default) >> /environment.txt
-RUN echo VALIDATE_MARKDOWN=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_MARKDOWN"'.default) >> /environment.txt
-RUN echo VALIDATE_POWERSHELL=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_POWERSHELL"'.default) >> /environment.txt
-RUN echo VALIDATE_RENOVATE=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_RENOVATE"'.default) >> /environment.txt
-RUN echo VALIDATE_XML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_XML"'.default) >> /environment.txt
-RUN echo VALIDATE_YAML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_YAML"'.default) >> /environment.txt
+RUN echo "export RUN_LOCAL=TRUE" >> /super-linter.txt
+RUN echo "export DEFAULT_BRANCH=main" >> /super-linter.txt
+RUN echo "export DEFAULT_WORKSPACE=/src" >> /super-linter.txt
+RUN echo BASH_SEVERITY=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."BASH_SEVERITY"'.default) >> /super-linter.txt
+RUN echo VALIDATE_BASH=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH"'.default) >> /super-linter.txt
+RUN echo VALIDATE_BASH_EXEC=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH_EXEC"'.default) >> /super-linter.txt
+RUN echo VALIDATE_CSS=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_CSS"'.default) >> /super-linter.txt
+RUN echo VALIDATE_DOCKERFILE_HADOLINT=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_DOCKERFILE_HADOLINT"'.default) >> /super-linter.txt
+RUN echo VALIDATE_GITHUB_ACTIONS=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_GITHUB_ACTIONS"'.default) >> /super-linter.txt
+RUN echo VALIDATE_HTML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_HTML"'.default) >> /super-linter.txt
+RUN echo VALIDATE_JAVASCRIPT_ES=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JAVASCRIPT_ES"'.default) >> /super-linter.txt
+RUN echo VALIDATE_JAVASCRIPT_STANDARD=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JAVASCRIPT_STANDARD"'.default) >> /super-linter.txt
+RUN echo VALIDATE_JSON=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JSON"'.default) >> /super-linter.txt
+RUN echo VALIDATE_MARKDOWN=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_MARKDOWN"'.default) >> /super-linter.txt
+RUN echo VALIDATE_POWERSHELL=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_POWERSHELL"'.default) >> /super-linter.txt
+RUN echo VALIDATE_RENOVATE=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_RENOVATE"'.default) >> /super-linter.txt
+RUN echo VALIDATE_XML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_XML"'.default) >> /super-linter.txt
+RUN echo VALIDATE_YAML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_YAML"'.default) >> /super-linter.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3-slim
+FROM ghcr.io/super-linter/super-linter:latest
+# FROM python:3-slim
 
 # This Dockerfile is used by the linting pre-commit hook.
 # Unfortunately there is no config option yet to specify the name or path
 # of this image, so it must be on root level simply named Dockerfile...
 
-RUN apt-get update && apt-get install jq wget -y
+RUN apk add jq wget
 RUN pip install --upgrade pip yq virtualenv toml-union
 
 # Copy linting workflow to identify linter versions if needed
@@ -22,3 +23,23 @@ RUN pip install -r requirements.txt
 COPY pre_commit_hooks/linting.sh /linting.sh
 
 CMD [ "bash /linting.sh" ]
+
+
+
+#######
+# save to be able to export later
+RUN echo BASH_SEVERITY=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."BASH_SEVERITY"'.default) >> /environment.txt
+RUN echo VALIDATE_BASH=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH"'.default) >> /environment.txt
+RUN echo VALIDATE_BASH_EXEC=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_BASH_EXEC"'.default) >> /environment.txt
+RUN echo VALIDATE_CSS=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_CSS"'.default) >> /environment.txt
+RUN echo VALIDATE_DOCKERFILE_HADOLINT=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_DOCKERFILE_HADOLINT"'.default) >> /environment.txt
+RUN echo VALIDATE_GITHUB_ACTIONS=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_GITHUB_ACTIONS"'.default) >> /environment.txt
+RUN echo VALIDATE_HTML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_HTML"'.default) >> /environment.txt
+RUN echo VALIDATE_JAVASCRIPT_ES=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JAVASCRIPT_ES"'.default) >> /environment.txt
+RUN echo VALIDATE_JAVASCRIPT_STANDARD=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JAVASCRIPT_STANDARD"'.default) >> /environment.txt
+RUN echo VALIDATE_JSON=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_JSON"'.default) >> /environment.txt
+RUN echo VALIDATE_MARKDOWN=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_MARKDOWN"'.default) >> /environment.txt
+RUN echo VALIDATE_POWERSHELL=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_POWERSHELL"'.default) >> /environment.txt
+RUN echo VALIDATE_RENOVATE=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_RENOVATE"'.default) >> /environment.txt
+RUN echo VALIDATE_XML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_XML"'.default) >> /environment.txt
+RUN echo VALIDATE_YAML=$(cat $WORKFLOW_LINTING_WORKFLOW | yq .on.workflow_call.inputs | jq -r '."VALIDATE_YAML"'.default) >> /environment.txt

--- a/docker/super-linter/Dockerfile
+++ b/docker/super-linter/Dockerfile
@@ -1,9 +1,0 @@
-FROM ghcr.io/super-linter/super-linter:latest
-
-# pre-commit seems to set too strict permissions:
-# error: could not lock config file //.gitconfig: Permission denied
-# Therefore do not configure globally
-# https://github.com/super-linter/super-linter/blob/main/lib/linter.sh#L345
-RUN sed -i 's+git config --global --add safe.directory+git config --add safe.directory+g' /action/lib/linter.sh
-
-# push to mundialis/super-linter

--- a/docker/super-linter/Dockerfile
+++ b/docker/super-linter/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/super-linter/super-linter:latest
+
+# pre-commit seems to set too strict permissions:
+# error: could not lock config file //.gitconfig: Permission denied
+# Therefore do not configure globally
+# https://github.com/super-linter/super-linter/blob/main/lib/linter.sh#L345
+RUN sed -i 's+git config --global --add safe.directory+git config --add safe.directory+g' /action/lib/linter.sh
+
+# push to mundialis/super-linter

--- a/pre_commit_hooks/linting.sh
+++ b/pre_commit_hooks/linting.sh
@@ -220,12 +220,10 @@ then
     echo
     echo "SUPERLINTER:"
     # overwrite rules with default config
-    . /environment.txt
-    export $(cut -d= -f1 /environment.txt)
+    . /super-linter.txt && export $(cut -d= -f1 /super-linter.txt)
     # overwrite rules with custom repo config
-    `cat /tmp/lint/.github/workflows/linting.yml | yq .jobs.lint.with | grep -v "-version" | jq -r 'to_entries[] | "export \(.key)=\(.value)"'`
-    export RUN_LOCAL=TRUE
-    export DEFAULT_BRANCH=main
+    `cat /src/.github/workflows/linting.yml | yq .jobs.lint.with | grep -v "-version" | jq -r 'to_entries[] | "export \(.key)=\(.value)"'`
+    # run linting script
     bash /action/lib/linter.sh
     if [ $? -ne 0 ]
     then

--- a/pre_commit_hooks/linting.sh
+++ b/pre_commit_hooks/linting.sh
@@ -39,10 +39,11 @@ then
     then
         RUN_BLACK=FALSE
         echo "- black configured to be skipped (empty string)"
-    elif [ $DEFAULT_BLACK_VERSION != $NEW_BLACK_VERSION ]
+    elif [ $DEFAULT_BLACK_VERSION != `echo $NEW_BLACK_VERSION | tr -d '"'` ]
     then
-        # sed would fail with Permission denied
+        # sed or pip would fail with Permission denied
         # sed -i "s+$DEFAULT_BLACK_VERSION+$NEW_BLACK_VERSION+g" /requirements.txt
+        # pip3 install black==`echo $NEW_BLACK_VERSION | tr -d '"'`
         echo "- Warning: overwritten black version will not be installed!"
     fi
 else
@@ -109,7 +110,7 @@ echo
 # Install linters #
 ###################
 # TODO: if versions are not default versions, this fails due to missing permissions
-pip3 install -r /requirements.txt
+# pip3 install -r /requirements.txt
 echo
 echo "flake8: `flake8 --version`"
 echo "pylint: `pylint --version`"
@@ -222,7 +223,7 @@ then
     # overwrite rules with default config
     . /super-linter.txt && export $(cut -d= -f1 /super-linter.txt)
     # overwrite rules with custom repo config
-    `cat /src/.github/workflows/linting.yml | yq .jobs.lint.with | grep -v "-version" | jq -r 'to_entries[] | "export \(.key)=\(.value)"'`
+    `cat /src/.github/workflows/linting.yml | yq .jobs.lint.with | grep -v "-version" | tr -d ',' | jq -r 'to_entries[] | "export \(.key)=\(.value)"'`
     # run linting script
     bash /action/lib/linter.sh
     if [ $? -ne 0 ]


### PR DESCRIPTION
Follow up of https://github.com/mundialis/github-workflows/pull/27
- Adding super-linter to pre-commit
- Config options can be read from the linting workflow
- Overwriting config options from repo specific linting workflow are used (for super-linter config only)
- prevents run of multiple times