### PR TITLE
Rm temp ruff config

### DIFF
--- a/.github/workflows/grass-tests.yml
+++ b/.github/workflows/grass-tests.yml
@@ -20,8 +20,8 @@ jobs:
     - name: add Dockerfile and test skript
       run: |
         ( mkdir -p test-docker && cd test-docker && \
-          wget https://raw.githubusercontent.com/mundialis/github-workflows/grass_test_improvements/grass-gis-test-docker/Dockerfile \
-          && wget https://raw.githubusercontent.com/mundialis/github-workflows/grass_test_improvements/grass-gis-test-docker/test.sh )
+          wget https://raw.githubusercontent.com/mundialis/github-workflows/main/grass-gis-test-docker/Dockerfile \
+          && wget https://raw.githubusercontent.com/mundialis/github-workflows/main/grass-gis-test-docker/test.sh )
     - name: Tests of GRASS GIS addon
       id: docker_build
       uses: docker/build-push-action@v6

--- a/.github/workflows/grass-tests.yml
+++ b/.github/workflows/grass-tests.yml
@@ -20,8 +20,8 @@ jobs:
     - name: add Dockerfile and test skript
       run: |
         ( mkdir -p test-docker && cd test-docker && \
-          wget https://raw.githubusercontent.com/mundialis/github-workflows/main/grass-gis-test-docker/Dockerfile \
-          && wget https://raw.githubusercontent.com/mundialis/github-workflows/main/grass-gis-test-docker/test.sh )
+          wget https://raw.githubusercontent.com/mundialis/github-workflows/grass_test_improvements/grass-gis-test-docker/Dockerfile \
+          && wget https://raw.githubusercontent.com/mundialis/github-workflows/grass_test_improvements/grass-gis-test-docker/test.sh )
     - name: Tests of GRASS GIS addon
       id: docker_build
       uses: docker/build-push-action@v6

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -203,7 +203,7 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
       - name: Lint code base
-        uses: super-linter/super-linter/slim@88ea3923a7e1f89dd485d079f6eb5f5e8f937589 # v6.6.0
+        uses: super-linter/super-linter/slim@1fa6ba58a88783e9714725cf89ac26d53e80c148 # v6.9.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -203,7 +203,7 @@ jobs:
           # list of files that changed across commits
           fetch-depth: 0
       - name: Lint code base
-        uses: super-linter/super-linter/slim@1fa6ba58a88783e9714725cf89ac26d53e80c148 # v6.9.0
+        uses: super-linter/super-linter/slim@e1cb86b6e8d119f789513668b4b30bf17fe1efe4 # v7.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: main

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -169,7 +169,7 @@ jobs:
       if: ${{ hashFiles('ruff.toml') == '' }}
       run: |
         echo "ruff.toml does not exists. Will be downloaded."
-        wget https://raw.githubusercontent.com/mundialis/github-workflows/main/linting-config-examples/ruff.toml
+        wget https://raw.githubusercontent.com/mundialis/github-workflows/main/linting-config-examples/ruff.toml && touch rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4
     - name: Run ruff (output annotations on fixable errors)
       run: |
         ruff check --config ruff.toml --output-format=github . --preview --unsafe-fixes
@@ -177,6 +177,10 @@ jobs:
     - name: Run ruff (apply fixes for suggestions)
       run: |
         ruff check --config ruff.toml . --preview --fix --unsafe-fixes
+    - name: No diff for temp ruff.toml
+      if: ${{ hashFiles('rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4') != '' }}
+      run: |
+        rm rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4 && rm ruff.toml
     - name: Create and upload code suggestions to apply for ruff
       id: diff-ruff
       if: ${{ !cancelled() }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -197,7 +197,7 @@ jobs:
       # To report GitHub Actions status checks
       statuses: write
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits

--- a/grass-gis-test-docker/Dockerfile
+++ b/grass-gis-test-docker/Dockerfile
@@ -1,11 +1,18 @@
-FROM osgeo/grass-gis:current-alpine
+FROM osgeo/grass-gis:main-alpine
 
 ARG NC_TEST_DATA=""
 
 WORKDIR /src
 COPY . /src
 COPY test-docker/test.sh /src
+
+RUN test -e test-docker/ && rm -rf test-docker/
+
 RUN apk add gcc make python3-dev musl-dev linux-headers
+
+# create environment to install requirements
+RUN python -m venv addon-env
+ENV PATH="/src/addon-env/bin:$PATH"
 RUN test -e requirements.txt && pip3 install -r requirements.txt || echo "No requirements.txt"
 
 # run tests if NC_TEST_DATA is set to NC with downloaded NC test loaction otherwise in empty location

--- a/grass-gis-test-docker/test.sh
+++ b/grass-gis-test-docker/test.sh
@@ -31,7 +31,7 @@ do  \
     echo ${file}
     BASENAME=$(basename "${file}") ; \
     DIR=$(dirname "${file}") ; \
-    cd ${CURRENTDIR}/${DIR} && python3 -m unittest ${BASENAME}
+    cd ${CURRENTDIR}/${DIR} && python -m unittest ${BASENAME}
     for res_file in $(test_keyvalue_result_*.txt) ; do
       cat ${res_file}
     done

--- a/grass-gis-test-docker/test.sh
+++ b/grass-gis-test-docker/test.sh
@@ -26,11 +26,14 @@ fi
 g.extension extension=${ADDON} url=. && \
 for file in $(find . -type f -name test*.py) ; \
 do  \
-  echo ${file}
-  BASENAME=$(basename "${file}") ; \
-  DIR=$(dirname "${file}") ; \
-  cd ${CURRENTDIR}/${DIR} && python3 -m unittest ${BASENAME}
-  for res_file in $(test_keyvalue_result_*.txt) ; do
-    cat ${res_file}
-  done
+  if [[ ${file} != *"addon-env"* ]] ;
+  then
+    echo ${file}
+    BASENAME=$(basename "${file}") ; \
+    DIR=$(dirname "${file}") ; \
+    cd ${CURRENTDIR}/${DIR} && python3 -m unittest ${BASENAME}
+    for res_file in $(test_keyvalue_result_*.txt) ; do
+      cat ${res_file}
+    done
+  fi
 done


### PR DESCRIPTION
If in a repository using the linting workflow no ruff config exists, the linting workflow downloads the default ruff.toml from this repo. So far so good. But this leads to a diff in the repository when checked with the "Create and upload code suggestions to apply for ruff" from OSGeo/grass/.github/actions/create-upload-suggestions .
To avoid this, a temporary file is created when a new ruff.toml is downloaded to be able to decide wether it should be removed later before the create-upload-suggestions step.