### PR TITLE
Rm temp ruff config

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -169,7 +169,7 @@ jobs:
       if: ${{ hashFiles('ruff.toml') == '' }}
       run: |
         echo "ruff.toml does not exists. Will be downloaded."
-        wget https://raw.githubusercontent.com/mundialis/github-workflows/main/linting-config-examples/ruff.toml
+        wget https://raw.githubusercontent.com/mundialis/github-workflows/main/linting-config-examples/ruff.toml && touch rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4
     - name: Run ruff (output annotations on fixable errors)
       run: |
         ruff check --config ruff.toml --output-format=github . --preview --unsafe-fixes
@@ -177,6 +177,10 @@ jobs:
     - name: Run ruff (apply fixes for suggestions)
       run: |
         ruff check --config ruff.toml . --preview --fix --unsafe-fixes
+    - name: No diff for temp ruff.toml
+      if: ${{ hashFiles('rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4') != '' }}
+      run: |
+        rm rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4 && rm ruff.toml
     - name: Create and upload code suggestions to apply for ruff
       id: diff-ruff
       if: ${{ !cancelled() }}


### PR DESCRIPTION
If in a repository using the linting workflow no ruff config exists, the linting workflow downloads the default ruff.toml from this repo. So far so good. But this leads to a diff in the repository when checked with the "Create and upload code suggestions to apply for ruff" from OSGeo/grass/.github/actions/create-upload-suggestions .
To avoid this, a temporary file is created when a new ruff.toml is downloaded to be able to decide wether it should be removed later before the create-upload-suggestions step.

Successfully tested in actinia-core https://github.com/actinia-org/actinia-core/actions/runs/12065648595/job/33644875757?pr=574