### PR TITLE
Enhance ruff config

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -163,20 +163,30 @@ jobs:
     - name: Install pip dependencies
       run: |
         python -m pip install --upgrade pip
-        pip3 install ruff==${{ inputs.ruff-version }}
+        pip3 install ruff==${{ inputs.ruff-version }} toml-union
         ruff --version
     - name: Configure ruff
+      run: |
+        echo "Download ruff.toml..."
+        wget https://raw.githubusercontent.com/mundialis/github-workflows/main/linting-config-examples/ruff.toml -O ruff-github-workflows.toml
+    - name: Mock ruff config if not exists
       if: ${{ hashFiles('ruff.toml') == '' }}
       run: |
-        echo "ruff.toml does not exists. Will be downloaded."
-        wget https://raw.githubusercontent.com/mundialis/github-workflows/main/linting-config-examples/ruff.toml && touch rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4
+        touch ruff.toml && touch rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4
+    - name: Merge ruff config
+      run: |
+        toml-union ruff.toml ruff-github-workflows.toml -o ruff-merged.toml
     - name: Run ruff (output annotations on fixable errors)
       run: |
-        ruff check --config ruff.toml --output-format=github . --preview --unsafe-fixes
+        ruff check --config ruff-merged.toml --output-format=github . --preview --unsafe-fixes
       continue-on-error: true
     - name: Run ruff (apply fixes for suggestions)
       run: |
-        ruff check --config ruff.toml . --preview --fix --unsafe-fixes
+        ruff check --config ruff-merged.toml . --preview --fix --unsafe-fixes
+    - name: No diff for merged ruff.toml
+      if: ${{ hashFiles('ruff-github-workflows.toml') != '' }}
+      run: |
+        rm ruff-github-workflows.toml && rm ruff-merged
     - name: No diff for temp ruff.toml
       if: ${{ hashFiles('rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4') != '' }}
       run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -186,7 +186,7 @@ jobs:
     - name: No diff for merged ruff.toml
       if: ${{ hashFiles('ruff-github-workflows.toml') != '' }}
       run: |
-        rm ruff-github-workflows.toml && rm ruff-merged
+        rm ruff-github-workflows.toml && rm ruff-merged.toml
     - name: No diff for temp ruff.toml
       if: ${{ hashFiles('rmruff-e922498e-5492-4fb2-86d5-09a0a7e0d0a4') != '' }}
       run: |

--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ jobs:
 Examples how `flake8`, `pylint`, `markdownlint`, `shellcheck` and `ruff` can be configured are in the
 [linting-config-examples](linting-config-examples)
 folder. The `pylint` and `ruff` configuration files do not need to be created if they
-are not to be customized, scince they will be copied by the workflow if they
-do not exists. See [linting-config-examples](linting-config-examples/README.md) for more
+are not to be customized, since they will be copied by the workflow if they
+do not exists, although an additional `ruff.toml` file will be merged.
+See [linting-config-examples](linting-config-examples/README.md) for more
 details on how to configure the individual linters.
 
 If one of the versions is set to an empty string the code quality check will be

--- a/linting-config-examples/README.md
+++ b/linting-config-examples/README.md
@@ -23,8 +23,18 @@ same way and place them in your directory root to adjust.
 `pylint --rc-file=.pylintrc_allowed_to_fail .`
 
 ## ruff
-ruff contains rules inspired by black, flake8, pylint and more and is extremely fast in linting and formatting Python code. Simply add a ruff.toml config file to the root of your repository.
-See example here or visit [official documentation](https://docs.astral.sh/ruff/). `ruff check --config ruff.toml .`
+ruff contains rules inspired by black, flake8, pylint and more and is extremely fast in linting and formatting Python code.
+The linting config is aligned to the [one from GRASS GIS](https://github.com/OSGeo/grass/blob/main/pyproject.toml).
+Per default, a lot of linting rules are active. If needed, add a `ruff.toml` config file to the root of your repository
+and add rules which to ignore.
+See example here or visit [official documentation](https://docs.astral.sh/ruff/).
+`ruff check --config ruff-merged.toml --output-format=full . --preview --unsafe-fixes`
+Merge repository-specific `ruff.toml` and the one from this repo:
+`pip install toml-union`
+`toml-union ruff.toml ~/repos/github-workflows/linting-config-examples/ruff.toml -o ruff-merged.toml`
+For initial setup in your repository, the list of rules to be ignored can be generated:
+`ruff check --config ruff-merged.toml . --preview --unsafe-fixes --output-format json | jq .[].code | sort -u`
+(Need to add `,` at the end of each line).
 
 ## superlinter
 Superlinter is a wrapper for many different linters. Each has a different way to be configured.

--- a/linting-config-examples/ruff.toml
+++ b/linting-config-examples/ruff.toml
@@ -1,39 +1,85 @@
 # Ruff configuration file: ruff.toml
 
-# Define the required version for Ruff
 required-version = ">=0.7.0"
 
 line-length = 79
 
-# Specify directories or files to be excluded from Ruff linting, in addition to default exclusions
-extend-exclude = [
-    ".git",
-    "__pycache__",
-    ".env",
-    ".venv",
-    "env",
-    "venv",
-    "ENV",
-    "env.bak",
-    "venv.bak",
-    "ctypes",
-    "pydispatch",
+builtins = ["_"]
+
+# Define linting rules selection
+# See https://docs.astral.sh/ruff/rules/
+# ## double comment does not exist in GRASS GIS config
+# select all other options here and disable if needed
+# in repositories usig this.
+lint.select = [
+    "A",      # flake8-builtins (A)
+    "AIR",    # Airflow (AIR)
+    "ANN",    # flake8-annotations (ANN)
+    "ARG",    # flake8-unused-arguments (ARG)
+##    "ASYNC",  # flake8-async (ASYNC)
+    "B",      # flake8-bugbear (B)
+    "BLE",    # flake8-blind-except (BLE)
+##    "C4",     # flake8-comprehensions (C4)
+##    "C90",    # mccabe (C90)
+    "COM",    # flake8-commas (COM)
+##    "CPY",    # flake8-copyright (CPY)
+##    "DJ",     # flake8-django (DJ)
+##    "DOC",    # pydoclint (DOC)
+    "D",      # pydocstyle (D)
+    "DTZ",    # flake8-datetimez (DTZ)
+##    "EM",     # flake8-errmsg (EM)
+    "E",      # pycodestyle Error (E)
+##    "ERA",    # eradicate (ERA)
+##    "EXE",    # flake8-executable (EXE)
+    "FA",     # flake8-future-annotations (FA)
+##    "FAST",   # FastAPI (FAST)
+    "FBT",    # flake8-boolean-trap (FBT)
+##    "FIX",    # flake8-fixme (FIX)
+    "FLY",    # flynt (FLY)
+    "F",      # Pyflakes (F)
+    "FURB",   # refurb (FURB)
+    "G",      # flake8-logging-format (G)
+    "ICN",    # flake8-import-conventions (ICN)
+    "I",      # isort (I)
+##    "INP",    # flake8-no-pep420 (INP)
+    "INT",    # flake8-gettext (INT)
+    "ISC",    # flake8-implicit-str-concat (ISC)
+    "LOG",    # flake8-logging (LOG)
+    "N",      # pep8-naming (N)
+    "NPY",    # NumPy-specific rules (NPY)
+##    "PD",     # pandas-vet (PD)
+    "PERF",   # Perflint (PERF)
+    "PGH",    # pygrep-hooks (PGH)
+    "PIE",    # flake8-pie (PIE)
+    "PLC",    # Pylint Convention (PLC)
+    "PLE",    # Pylint Error (PLE)
+    "PLR",    # Pylint Refactor (PLR)
+    "PLW",    # Pylint Warning (PLW)
+    "PT",     # flake8-pytest-style (PT)
+    "PTH",    # flake8-use-pathlib (PTH)
+##    "PYI",    # flake8-pyi (PYI)
+    "Q",      # flake8-quotes (Q)
+    "RET",    # flake8-return (RET)
+    "RSE",    # flake8-raise (RSE)
+    "RUF",    # Ruff-specific rules (RUF)
+    "S",      # flake8-bandit (S)
+    "SIM",    # flake8-simplify (SIM)
+    "SLF",    # flake8-self (SLF)
+    "SLOT",   # flake8-slots (SLOT)
+    "T10",    # flake8-debugger (T10)
+##    "T20",    # flake8-print (T20)
+    "TCH",    # flake8-type-checking (TCH)
+##    "TD",     # flake8-todos (TD)
+    "TID",    # flake8-tidy-imports (TID)
+    "TRY",    # tryceratops (TRY)
+    "UP",     # pyupgrade (UP)
+    "W",      # pycodestyle Warning (W)
+    "YTT",    # flake8-2020 (YTT)
 ]
 
-# Uncomment the following sections as needed
+# Overwrite the following sections as needed
+# in the repositories using the lint workflow.
 
-# [format]
-# Format settings for Ruff (quote-style and indent-style)
-# quote-style = "double"
-# indent-style= "tab"
-
-# [lint]
-# Define linting rules selection and ignore list
-# select = [
-#     "A",        # flake8-builtins (A)
-#     "COM",      # flake8-commas
-#     "PL",       # Pylint
-# ]
 # ignore = [
 #     "E402",     # module-import-not-at-top-of-file
 #     "E501",     # line-too-long


### PR DESCRIPTION
This PR enhances the ruff config. It makes it more strict by selecting more rules to align to the GRASS GIS ruff config.
The workflow is adjusted to now always download this ruff config file and then merge it with a local config if any.
In this local config, rules which should be ignored can be configured.