### PR TITLE
Decide for conflicting rules

### DIFF
--- a/linting-config-examples/ruff.toml
+++ b/linting-config-examples/ruff.toml
@@ -82,6 +82,7 @@ lint.select = [
 
 lint.ignore = [
       "D203",     # one-blank-line-before-class
+      "D213",     # multi-line-summary-second-line
 #     "E402",     # module-import-not-at-top-of-file
 #     "E501",     # line-too-long
 ]

--- a/linting-config-examples/ruff.toml
+++ b/linting-config-examples/ruff.toml
@@ -80,10 +80,11 @@ lint.select = [
 # Overwrite the following sections as needed
 # in the repositories using the lint workflow.
 
-# ignore = [
+ignore = [
+      "D203",     # one-blank-line-before-class
 #     "E402",     # module-import-not-at-top-of-file
 #     "E501",     # line-too-long
-# ]
+]
 
 # [lint.per-file-ignores]
 # Define file-specific linting rule ignores

--- a/linting-config-examples/ruff.toml
+++ b/linting-config-examples/ruff.toml
@@ -80,7 +80,7 @@ lint.select = [
 # Overwrite the following sections as needed
 # in the repositories using the lint workflow.
 
-ignore = [
+lint.ignore = [
       "D203",     # one-blank-line-before-class
 #     "E402",     # module-import-not-at-top-of-file
 #     "E501",     # line-too-long


### PR DESCRIPTION
Depending on the linted files with ruff, the following warnings are shown:
```
warning: `one-blank-line-before-class` (D203) and `no-blank-line-before-class` (D211) are incompatible. Ignoring `one-blank-line-before-class`.
```
```
warning: `multi-line-summary-first-line` (D212) and `multi-line-summary-second-line` (D213) are incompatible. Ignoring `multi-line-summary-second-line`.
```

This happens because of conflicting pydocstyle rules https://docs.astral.sh/ruff/rules/#pydocstyle-d

This PR decides which ones to ignore. It is merged with the repo specific rules to ignore and cannot be overwritten by repo specific rules to ignore.