### PR TITLE
add option to exclude files from linting with super-linter

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -79,6 +79,9 @@ on:
         required: false
         type: boolean
         default: true
+      FILTER_REGEX_EXCLUDE:
+        required: false
+        type: string
 
 jobs:
   flake8:
@@ -226,3 +229,4 @@ jobs:
           VALIDATE_RENOVATE: "${{ inputs.VALIDATE_RENOVATE == true && true || '' }}"
           VALIDATE_XML: "${{ inputs.VALIDATE_XML == true && true || '' }}"
           VALIDATE_YAML: "${{ inputs.VALIDATE_YAML == true && true || '' }}"
+          FILTER_REGEX_EXCLUDE: ${{ inputs.FILTER_REGEX_EXCLUDE }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -79,7 +79,7 @@ on:
         required: false
         type: boolean
         default: true
-      FILTER_REGEX_EXCLUDE:
+      SUPER_LINTER_FILTER_REGEX_EXCLUDE:
         required: false
         type: string
 
@@ -229,4 +229,4 @@ jobs:
           VALIDATE_RENOVATE: "${{ inputs.VALIDATE_RENOVATE == true && true || '' }}"
           VALIDATE_XML: "${{ inputs.VALIDATE_XML == true && true || '' }}"
           VALIDATE_YAML: "${{ inputs.VALIDATE_YAML == true && true || '' }}"
-          FILTER_REGEX_EXCLUDE: ${{ inputs.FILTER_REGEX_EXCLUDE }}
+          FILTER_REGEX_EXCLUDE: ${{ inputs.SUPER_LINTER_FILTER_REGEX_EXCLUDE }}

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ do not exists, although an additional `ruff.toml` file will be merged.
 See [linting-config-examples](linting-config-examples/README.md) for more
 details on how to configure the individual linters.
 
+To exclude files (files, folders or patterns) from linting completely 
+(e.g. to exclude specific files from JSON linting via super-linter) 
+add them to the `linting.yml` in the repo where the workflow is used, e.g.:
+
+```
+jobs:
+  lint:
+    uses: mundialis/github-workflows/.github/workflows/linting.yml@main
+    with:
+      FILTER_REGEX_EXCLUDE: ".*processing/templates/template_MAIN_loop.json"
+```
+
+Attention: This skips the whole file during linting! -> all-or-nothing per file
+
 ### (Python) Linting - reviewdog
 
 For `ruff` and `black` linting, another workflow can propose suggestions to a pull request.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ do not exists, although an additional `ruff.toml` file will be merged.
 See [linting-config-examples](linting-config-examples/README.md) for more
 details on how to configure the individual linters.
 
-To exclude files (files, folders or patterns) from linting completely 
+To exclude files (files, folders or patterns) to be linted with super linter completely 
 (e.g. to exclude specific files from JSON linting via super-linter) 
 add them to the `linting.yml` in the repo where the workflow is used, e.g.:
 
@@ -47,10 +47,16 @@ jobs:
   lint:
     uses: mundialis/github-workflows/.github/workflows/linting.yml@main
     with:
-      FILTER_REGEX_EXCLUDE: ".*processing/templates/template_MAIN_loop.json"
+      SUPER_LINTER_FILTER_REGEX_EXCLUDE: ".*processing/templates/template_MAIN_loop.json"
 ```
 
-Attention: This skips the whole file during linting! -> all-or-nothing per file
+Attention: This skips the whole file to be linted with super-linter!
+ -> all-or-nothing per file
+To exlude python files, use the dedicated exclude configs (e.g. `.flake8`).
+
+Always prefer to exlude more specific rules instead of a whole file 
+as explained in the [linting-config-example](https://github.com/mundialis/github-workflows/tree/main/linting-config-examples#superlinter)
+
 
 ### (Python) Linting - reviewdog
 


### PR DESCRIPTION
This MR adds the option to exlcude files from linting with super-linter in repos, where the reusable workflow is used.

To exclude files from linting with super-linter add them to the `linting.yml` in the corresponding repo, like:

```
jobs:
  lint:
    uses: mundialis/github-workflows/.github/workflows/linting.yml@main
    with:
      FILTER_REGEX_EXCLUDE: ".*processing/templates/template_MAIN_loop.json"
```

Attention: This skips the whole file during linting with super-linter! Other linters still apply.

