### PR TITLE
CI: pre-commit activated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pylintrc
+.pylintrc_allowed_to_fail
+ruff-github-workflows.toml
+ruff-merged.toml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+-   repo: https://github.com/mundialis/github-workflows
+    rev: 1.6.0
+    hooks:
+    -   id: linting

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ do not exists, although an additional `ruff.toml` file will be merged.
 See [linting-config-examples](linting-config-examples/README.md) for more
 details on how to configure the individual linters.
 
-To exclude files (files, folders or patterns) to be linted with super linter completely 
-(e.g. to exclude specific files from JSON linting via super-linter) 
+To exclude files (files, folders or patterns) to be linted with super linter completely
+(e.g. to exclude specific files from JSON linting via super-linter)
 add them to the `linting.yml` in the repo where the workflow is used, e.g.:
 
 ```
@@ -54,7 +54,7 @@ Attention: This skips the whole file to be linted with super-linter!
  -> all-or-nothing per file
 To exlude python files, use the dedicated exclude configs (e.g. `.flake8`).
 
-Always prefer to exlude more specific rules instead of a whole file 
+Always prefer to exlude more specific rules instead of a whole file
 as explained in the [linting-config-example](https://github.com/mundialis/github-workflows/tree/main/linting-config-examples#superlinter)
 
 


### PR DESCRIPTION
This PR activates `pre-commit` including (minor) needed reformatting.

Supported by`opencode` , DeepSeek V4 Flash Free (OpenCode Zen)

See also <https://github.com/mundialis/github-workflows/tree/main#pre-commit>

Requires #79