### PR TITLE
CI: disable markdown MD041 error

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -225,6 +225,7 @@ jobs:
           VALIDATE_JAVASCRIPT_STANDARD: "${{ inputs.VALIDATE_JAVASCRIPT_STANDARD == true && true || '' }}"
           VALIDATE_JSON: "${{ inputs.VALIDATE_JSON == true && true || '' }}"
           VALIDATE_MARKDOWN: "${{ inputs.VALIDATE_MARKDOWN == true && true || '' }}"
+          MARKDOWNLINT_DISABLE_RULES: "MD041"
           VALIDATE_POWERSHELL: "${{ inputs.VALIDATE_POWERSHELL == true && true || '' }}"
           VALIDATE_RENOVATE: "${{ inputs.VALIDATE_RENOVATE == true && true || '' }}"
           VALIDATE_XML: "${{ inputs.VALIDATE_XML == true && true || '' }}"


### PR DESCRIPTION
Avoid error with GRASS markdown files (GRASS speciality that headings start with `##` in `.md` files):

`
  /github/workspace/g.extension.github.md:1 error MD041/first-line-heading/first-line-h1 First line in a file should be a top-level heading [Context: "## DESCRIPTION"]
`

by disabling `MD041/first-line-heading/first-line-h1` in superlinter