### PR TITLE
CI: pin Python 3.12 to avoid multiprocessing forkserver regression in 3.14

### DIFF
--- a/grass-gis-test-docker/Dockerfile
+++ b/grass-gis-test-docker/Dockerfile
@@ -8,10 +8,14 @@ COPY test-docker/test.sh /src
 
 RUN test -e test-docker/ && rm -rf test-docker/
 
-RUN apk add gcc make python3-dev musl-dev linux-headers
-
-# create environment to install requirements
-RUN python -m venv addon-env
+# Pin Python to 3.12 (from Alpine 3.20 compat repo) to avoid the
+# multiprocessing forkserver regression in Python 3.14 which breaks
+# GRASS's temporal RPC server (grass/pygrass/rpc/base.py thread_checker).
+# The forkserver address file is no longer found on Process.start()
+# in Python 3.14, causing FileNotFoundError during server restart.
+# See: https://github.com/mundialis/v.alkis.buildings.import/pull/30
+RUN apk add --no-cache python3.12 py3.12-pip python3.12-dev gcc make musl-dev linux-headers
+RUN python3.12 -m venv addon-env
 ENV PATH="/src/addon-env/bin:$PATH"
 RUN test -e requirements.txt && pip3 install -r requirements.txt || echo "No requirements.txt"
 


### PR DESCRIPTION
## Problem

Python 3.14 introduced a regression in the `multiprocessing` forkserver start method. When GRASS's temporal RPC server (`grass/pygrass/rpc/base.py` thread\_checker) tries to restart the server during cleanup via `Process.start()`, the forkserver address file is no longer found:

```
FileNotFoundError: [Errno 2] No such file or directory
  File ".../multiprocessing/forkserver.py", line 94, in connect_to_new_process
    client.connect(self._forkserver_address)
```

This causes test runs to fail with an unhandled exception in a background thread, even though the tests themselves pass.

## Solution

Pin the CI Docker image to use Python 3.12 instead of the default Python 3.14 from Alpine edge. Python 3.12 is available in Alpine repos and does not have the forkserver regression.

The `python3.12` package is installed explicitly and the venv is created with `python3.12 -m venv` to ensure all test dependencies use the correct Python version.

PR is AI-assisted with OpenCode (Deepseek v4 Flash)