### PR TITLE
Add reusable SBOM vulnerability workflow

### DIFF
--- a/.github/workflows/sbom-vulnerability-scan.yml
+++ b/.github/workflows/sbom-vulnerability-scan.yml
@@ -1,0 +1,45 @@
+name: SBOM Vulnerability Scan
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        description: "Path to the Dockerfile"
+        required: true
+        type: string
+      image:
+        description: "Name of the locally built Docker image"
+        required: false
+        default: "localbuild/testimage:latest"
+        type: string
+      fail-build:
+        description: "Fail the workflow when vulnerabilities above the severity cutoff are found"
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  sbom-vulnerability-scan:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v7
+
+      - name: Build the Docker image
+        run: docker build . --file "${{ inputs.dockerfile }}" --tag "${{ inputs.image }}"
+
+      - name: Generate SBOM and upload dependency results
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: "${{ inputs.image }}"
+          artifact-name: image.cyclonedx.json
+          output-file: image.cyclonedx.json
+          format: cyclonedx-json
+
+      - name: Scan SBOM for vulnerabilities
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
+        with:
+          sbom: image.cyclonedx.json
+          fail-build: ${{ inputs.fail-build }}
+          output-format: table

--- a/.github/workflows/sbom-vulnerability-scan.yml
+++ b/.github/workflows/sbom-vulnerability-scan.yml
@@ -38,8 +38,13 @@ jobs:
           format: cyclonedx-json
 
       - name: Scan SBOM for vulnerabilities
+        id: vulnerability-scan
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2
         with:
           sbom: image.cyclonedx.json
           fail-build: ${{ inputs.fail-build }}
-          output-format: table
+          output-format: sarif
+      - name: Upload vulnerability results to GitHub Security
+        uses: github/codeql-action/upload-sarif@24ea975727876cf496b1eb0c5b36e96e01600b51 # v4.37.0
+        with:
+          sarif_file: ${{ steps.vulnerability-scan.outputs.sarif }} 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,11 @@ jobs:
 ```
 ## SBOM Vulnerability Scan
 The SBOM vulnerability scan workflow builds a Docker image, generates a
-CycloneDX SBOM with Syft and scans the generated SBOM for known
-vulnerabilities with Grype.
+CycloneDX SBOM with Syft, scans the generated SBOM for known vulnerabilities
+with Grype, and uploads the vulnerability results to GitHub Code Scanning.
+
 You can use it e.g. like this:
+
 ```yaml
 name: SBOM Vulnerability Scan
 
@@ -186,6 +188,10 @@ on:
 
 jobs:
   sbom-scan:
+    permissions:
+      contents: read
+      security-events: write
+
     uses: mundialis/github-workflows/.github/workflows/sbom-vulnerability-scan.yml@main
     with:
       dockerfile: docker/actinia-core-alpine/Dockerfile
@@ -194,6 +200,11 @@ jobs:
 For reuse, the `dockerfile` input must be adapted to the path of the Dockerfile
 in the calling repository.
 
+The calling job requires the following permissions:
+
+- `contents: read` to check out the repository.
+- `security-events: write` to upload the vulnerability results to GitHub Code Scanning.
+
 Optional inputs:
 
 - `image`: Name and tag of the locally built Docker image. Default: `localbuild/testimage:latest`.
@@ -201,6 +212,8 @@ Optional inputs:
 cutoff are found.  Default: `false`.
 
 The generated SBOM is uploaded as `image.cyclonedx.json`.
+
+The vulnerability results are available under **Security and quality** → **Code scanning**.
 
 # pre-commit
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,35 @@ jobs:
     secrets:
       PYPI_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
 ```
+## SBOM Vulnerability Scan
+The SBOM vulnerability scan workflow builds a Docker image, generates a
+CycloneDX SBOM with Syft and scans the generated SBOM for known
+vulnerabilities with Grype.
+You can use it e.g. like this:
+```yaml
+name: SBOM Vulnerability Scan
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  sbom-scan:
+    uses: mundialis/github-workflows/.github/workflows/sbom-vulnerability-scan.yml@main
+    with:
+      dockerfile: docker/actinia-core-alpine/Dockerfile
+
+```
+For reuse, the `dockerfile` input must be adapted to the path of the Dockerfile
+in the calling repository.
+
+Optional inputs:
+
+- `image`: Name and tag of the locally built Docker image. Default: `localbuild/testimage:latest`.
+- `fail-build`: Set to `true` if the workflow should fail when vulnerabilities above the severity 
+cutoff are found.  Default: `false`.
+
+The generated SBOM is uploaded as `image.cyclonedx.json`.
 
 # pre-commit
 


### PR DESCRIPTION
This PR adds a reusable workflow to get the list of dependencies and vulnerabilities using Syft and Grype.
The README includes instructions for reuse and configurable inputs.
